### PR TITLE
Petapply w4

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationsController < ApplicationController
   def show
     @application = Application.find(params[:id])
+    @pet = Pet.find_by_name(params[:pet_name])
   end
 
   def new; end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -12,4 +12,8 @@ class Pet < ApplicationRecord
   def self.adoptable
     where(adoptable: true)
   end
+
+  def self.find_by_name(name)
+    where(name: name).first
+  end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -9,3 +9,13 @@
 <%= link_to pet.name, "/pets/#{pet.id}" %>
 <% end %>
 
+<h2> Add a Pet to this Application</h2>
+
+<%= form_with(url: "/applications/#{@application.id}", method: "GET") do |form| %>
+<%= form.label :pet_name %>
+<%= form.text_field :pet_name%>
+<%= form.submit "Submit" %>
+<% end %>
+<% if !@pet.nil? %>
+<%= link_to @pet.name, "/pets/#{@pet.id}" %>
+<% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,72 +10,71 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_09_223727) do
-
+ActiveRecord::Schema.define(version: 20_230_209_223_727) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "applications", force: :cascade do |t|
-    t.string "name"
-    t.string "address"
-    t.string "city"
-    t.string "state"
-    t.integer "zipcode"
-    t.string "description"
-    t.string "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'applications', force: :cascade do |t|
+    t.string 'name'
+    t.string 'address'
+    t.string 'city'
+    t.string 'state'
+    t.integer 'zipcode'
+    t.string 'description'
+    t.string 'status'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "pet_applications", force: :cascade do |t|
-    t.bigint "pet_id"
-    t.bigint "application_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["application_id"], name: "index_pet_applications_on_application_id"
-    t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
+  create_table 'pet_applications', force: :cascade do |t|
+    t.bigint 'pet_id'
+    t.bigint 'application_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['application_id'], name: 'index_pet_applications_on_application_id'
+    t.index ['pet_id'], name: 'index_pet_applications_on_pet_id'
   end
 
-  create_table "pets", force: :cascade do |t|
-    t.boolean "adoptable"
-    t.integer "age"
-    t.string "breed"
-    t.string "name"
-    t.bigint "shelter_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["shelter_id"], name: "index_pets_on_shelter_id"
+  create_table 'pets', force: :cascade do |t|
+    t.boolean 'adoptable'
+    t.integer 'age'
+    t.string 'breed'
+    t.string 'name'
+    t.bigint 'shelter_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['shelter_id'], name: 'index_pets_on_shelter_id'
   end
 
-  create_table "shelters", force: :cascade do |t|
-    t.boolean "foster_program"
-    t.string "name"
-    t.string "city"
-    t.integer "rank"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'shelters', force: :cascade do |t|
+    t.boolean 'foster_program'
+    t.string 'name'
+    t.string 'city'
+    t.integer 'rank'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  create_table "veterinarians", force: :cascade do |t|
-    t.boolean "on_call"
-    t.integer "review_rating"
-    t.string "name"
-    t.bigint "veterinary_office_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["veterinary_office_id"], name: "index_veterinarians_on_veterinary_office_id"
+  create_table 'veterinarians', force: :cascade do |t|
+    t.boolean 'on_call'
+    t.integer 'review_rating'
+    t.string 'name'
+    t.bigint 'veterinary_office_id'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['veterinary_office_id'], name: 'index_veterinarians_on_veterinary_office_id'
   end
 
-  create_table "veterinary_offices", force: :cascade do |t|
-    t.boolean "boarding_services"
-    t.integer "max_patient_capacity"
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+  create_table 'veterinary_offices', force: :cascade do |t|
+    t.boolean 'boarding_services'
+    t.integer 'max_patient_capacity'
+    t.string 'name'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
   end
 
-  add_foreign_key "pet_applications", "applications"
-  add_foreign_key "pet_applications", "pets"
-  add_foreign_key "pets", "shelters"
-  add_foreign_key "veterinarians", "veterinary_offices"
+  add_foreign_key 'pet_applications', 'applications'
+  add_foreign_key 'pet_applications', 'pets'
+  add_foreign_key 'pets', 'shelters'
+  add_foreign_key 'veterinarians', 'veterinary_offices'
 end

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe 'new application page' do
       click_on 'Submit'
 
       expect(current_path).to_not eq '/applications/new'
-      save_and_open_page
       expect(page).to have_content('My Application')
       expect(page).to have_content('123 Main Street')
       expect(page).to have_content('San Francisco')

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -16,7 +16,7 @@ describe 'app show page' do
                                  address: '123 Fake Street',
                                  city: 'Springfield',
                                  state: 'IL',
-                                 zipcode: 12_345,
+                                 zipcode: 12345,
                                  description: 'I like dogs.',
                                  status: 'In Progress')
     end
@@ -89,6 +89,51 @@ describe 'app show page' do
     it 'has app\'s status' do
       visit "/applications/#{@app.id}"
       expect(page).to have_content(@app.status)
+    end
+  end
+
+  describe 'Searching for pets' do
+    before(:each) do
+      @app = Application.create!(name: 'John Smith',
+                                 address: '123 Fake Street',
+                                 city: 'Springfield',
+                                 state: 'IL',
+                                 zipcode: 12345,
+                                 description: 'I like dogs.',
+                                 status: 'In Progress')
+    end
+# 4. Searching for Pets for an Application
+
+# As a visitor
+# When I visit an application's show page
+# And that application has not been submitted,
+# Then I see a section on the page to "Add a Pet to this Application"
+# In that section I see an input where I can search for Pets by name
+# When I fill in this field with a Pet's name
+# And I click submit,
+# Then I am taken back to the application show page
+# And under the search bar I see any Pet whose name matches my search
+    it 'has a section \'Add a Pet to this Application\' when not yet submitted' do
+      shelter = Shelter.create!(
+        foster_program: true,
+        name: 'Dog house',
+        city: 'Springfield',
+        rank: 1
+      )
+      fido = shelter.pets.create!(
+        adoptable: true,
+        age: 1,
+        breed: 'weiner',
+        name: 'Fido'
+      )
+      visit "/applications/#{@app.id}"
+      expect(@app.status).to eq('In Progress')
+      expect(page).to have_content('Add a Pet to this Application')
+      expect(page).to have_field('pet_name')
+      fill_in 'pet_name', with: 'Fido'
+      click_on 'Submit'
+      expect(current_path).to eq("/applications/#{@app.id}")
+      expect(page).to have_content('Fido')
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -16,7 +16,7 @@ describe 'app show page' do
                                  address: '123 Fake Street',
                                  city: 'Springfield',
                                  state: 'IL',
-                                 zipcode: 12345,
+                                 zipcode: 12_345,
                                  description: 'I like dogs.',
                                  status: 'In Progress')
     end
@@ -98,21 +98,21 @@ describe 'app show page' do
                                  address: '123 Fake Street',
                                  city: 'Springfield',
                                  state: 'IL',
-                                 zipcode: 12345,
+                                 zipcode: 12_345,
                                  description: 'I like dogs.',
                                  status: 'In Progress')
     end
-# 4. Searching for Pets for an Application
+    # 4. Searching for Pets for an Application
 
-# As a visitor
-# When I visit an application's show page
-# And that application has not been submitted,
-# Then I see a section on the page to "Add a Pet to this Application"
-# In that section I see an input where I can search for Pets by name
-# When I fill in this field with a Pet's name
-# And I click submit,
-# Then I am taken back to the application show page
-# And under the search bar I see any Pet whose name matches my search
+    # As a visitor
+    # When I visit an application's show page
+    # And that application has not been submitted,
+    # Then I see a section on the page to "Add a Pet to this Application"
+    # In that section I see an input where I can search for Pets by name
+    # When I fill in this field with a Pet's name
+    # And I click submit,
+    # Then I am taken back to the application show page
+    # And under the search bar I see any Pet whose name matches my search
     it 'has a section \'Add a Pet to this Application\' when not yet submitted' do
       shelter = Shelter.create!(
         foster_program: true,

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -128,6 +128,7 @@ describe 'app show page' do
       )
       visit "/applications/#{@app.id}"
       expect(@app.status).to eq('In Progress')
+      expect(page).to_not have_content('Fido')
       expect(page).to have_content('Add a Pet to this Application')
       expect(page).to have_field('pet_name')
       fill_in 'pet_name', with: 'Fido'

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Pet, type: :model do
         expect(Pet.adoptable).to eq([@pet_1, @pet_2])
       end
     end
+
+    describe '#find_by_name' do
+      it 'finds a pet by the name' do
+        expect(Pet.find_by_name(@pet_1.name)).to eq(@pet_1)
+      end
+    end
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
This commit fulfills user story 4:

[ ] done

4. Searching for Pets for an Application

As a visitor
When I visit an application's show page
And that application has not been submitted,
Then I see a section on the page to "Add a Pet to this Application"
In that section I see an input where I can search for Pets by name
When I fill in this field with a Pet's name
And I click submit,
Then I am taken back to the application show page
And under the search bar I see any Pet whose name matches my search