### PR TITLE
Petapply w6/7

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -12,8 +12,8 @@ class ApplicationsController < ApplicationController
     if application.save
       redirect_to "/applications/#{application.id}"
     else
-      redirect_to "/applications/new"
-      flash[:alert] = "Please provide a response for all fields."
+      redirect_to '/applications/new'
+      flash[:alert] = 'Please provide a response for all fields.'
     end
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,13 +19,11 @@ class ApplicationsController < ApplicationController
 
   def update
     application = Application.find(params[:id])
-    if !params[:pet_adopt].nil?
+    unless params[:pet_adopt].nil?
       pet = Pet.find(params[:pet_adopt])
       pet_application = PetApplication.create!(application_id: application.id, pet_id: pet.id)
     end
-    if !params[:description].nil?
-      application.update_attributes(description: params[:description], status: "Pending")
-    end
+    application.update_attributes(description: params[:description], status: 'Pending') unless params[:description].nil?
     redirect_to "/applications/#{application.id}"
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,8 +19,13 @@ class ApplicationsController < ApplicationController
 
   def update
     application = Application.find(params[:id])
-    pet = Pet.find(params[:pet_adopt])
-    pet_application = PetApplication.create!(application_id: application.id, pet_id: pet.id)
+    if !params[:pet_adopt].nil?
+      pet = Pet.find(params[:pet_adopt])
+      pet_application = PetApplication.create!(application_id: application.id, pet_id: pet.id)
+    end
+    if !params[:description].nil?
+      application.update_attributes(description: params[:description], status: "Pending")
+    end
     redirect_to "/applications/#{application.id}"
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -4,11 +4,11 @@ class Application < ApplicationRecord
   validates :city, presence: true
   validates :state, presence: true
   validates :zipcode, presence: true, numericality: true
-  
+
   has_many :pet_applications
   has_many :pets, through: :pet_applications
 
   def pets_list
-    self.pets.pluck(:name).join(', ').chomp.chomp
+    pets.pluck(:name).join(', ').chomp.chomp
   end
 end

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -27,4 +27,11 @@
      <%= form.submit "Adopt this Pet" %>
     <% end %>
   <% end %>
+
+  <%=form_with(url: "/applications/#{@application.id}", method: "PATCH") do |form| %>
+      <%= form.label :description, "Why would you make a good owner? " %>
+      <%= form.text_field :description%>
+     <%= form.submit "Submit Application" %>
+    <% end %>
 <% end %>
+

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -5,7 +5,10 @@
 <%= "Zip Code: " + @application.zipcode.to_s%><br>
 <%= "Description: " + @application.description%><br>
 <%= "Status: " + @application.status%><br>
-<%= "Pets Applying for: " + @application.pets_list%><br>
+<%= "Pets Applying for:" %>
+<% @application.pets.each do |pet| %>
+  <%= link_to pet.name, "/pets/#{pet.id}" %>
+<% end %>
 
 
 <h2> Add a Pet to this Application</h2>
@@ -15,14 +18,12 @@
 <%= form.text_field :pet_name%>
 <%= form.submit "Submit" %>
 <% end %>
-<%@application.pets.each do |pet|%>
-<%= link_to pet.name, "/pets/#{pet.id}" %>
-<% end %>
 <% if !@pets.nil? %>
   <% @pets.each do |pet| %>
     <%= link_to pet.name, "/pets/#{pet.id}" %>
     <%=form_with(url: "/applications/#{@application.id}", method: "PATCH") do |form| %>
       <%= form.hidden_field :pet_adopt, value:"#{pet.id}"%>
+      <%= form.hidden_field :pet_name, value:""%>
      <%= form.submit "Adopt this Pet" %>
     <% end %>
   <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,28 +6,28 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 @app = Application.create!(name: 'John Smith',
-  address: '123 Fake Street',
-  city: 'Springfield',
-  state: 'IL',
-  zipcode: 12_345,
-  description: 'I like dogs.',
-  status: 'In Progress')
+                           address: '123 Fake Street',
+                           city: 'Springfield',
+                           state: 'IL',
+                           zipcode: 12_345,
+                           description: 'I like dogs.',
+                           status: 'In Progress')
 
-  shelter = Shelter.create!(
-    foster_program: true,
-    name: 'Dog house',
-    city: 'Springfield',
-    rank: 1
-  )
-  fido = shelter.pets.create!(
-    adoptable: true,
-    age: 1,
-    breed: 'weiner',
-    name: 'Fido'
-  )
-  santa = shelter.pets.create!(
-    adoptable: true,
-    age: 1,
-    breed: 'whippet',
-    name: 'Santa\'s Little Helper'
-  )
+shelter = Shelter.create!(
+  foster_program: true,
+  name: 'Dog house',
+  city: 'Springfield',
+  rank: 1
+)
+fido = shelter.pets.create!(
+  adoptable: true,
+  age: 1,
+  breed: 'weiner',
+  name: 'Fido'
+)
+santa = shelter.pets.create!(
+  adoptable: true,
+  age: 1,
+  breed: 'whippet',
+  name: 'Santa\'s Little Helper'
+)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,29 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+@app = Application.create!(name: 'John Smith',
+  address: '123 Fake Street',
+  city: 'Springfield',
+  state: 'IL',
+  zipcode: 12_345,
+  description: 'I like dogs.',
+  status: 'In Progress')
+
+  shelter = Shelter.create!(
+    foster_program: true,
+    name: 'Dog house',
+    city: 'Springfield',
+    rank: 1
+  )
+  fido = shelter.pets.create!(
+    adoptable: true,
+    age: 1,
+    breed: 'weiner',
+    name: 'Fido'
+  )
+  santa = shelter.pets.create!(
+    adoptable: true,
+    age: 1,
+    breed: 'whippet',
+    name: 'Santa\'s Little Helper'
+  )

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -259,7 +259,7 @@ describe 'app show page' do
       petapp1 = PetApplication.create!(application_id: @app.id, pet_id: fido.id)
       petapp2 = PetApplication.create!(application_id: @app.id, pet_id: santa.id)
       visit "/applications/#{@app.id}"
-      expect(page).to have_content ("Submit Application")
+      expect(page).to have_button ("Submit Application")
       fill_in "description", with: "I like dogs and cats"
       click_button "Submit Application"
       expect(current_path).to eq "/applications/#{@app.id}"

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -215,28 +215,27 @@ describe 'app show page' do
     # And I see all the pets that I want to adopt
     # And I do not see a section to add more pets to this application
 
+    # 7. No Pets on an Application
 
-# 7. No Pets on an Application
-
-# As a visitor
-# When I visit an application's show page
-# And I have not added any pets to the application
-# Then I do not see a section to submit my application
+    # As a visitor
+    # When I visit an application's show page
+    # And I have not added any pets to the application
+    # Then I do not see a section to submit my application
 
     before(:each) do
       @app = Application.create!(name: 'John Smith',
-                                address: '123 Fake Street',
-                                city: 'Springfield',
-                                state: 'IL',
-                                zipcode: 12345,
-                                description: 'I like dogs.',
-                                status: 'In Progress')
+                                 address: '123 Fake Street',
+                                 city: 'Springfield',
+                                 state: 'IL',
+                                 zipcode: 12_345,
+                                 description: 'I like dogs.',
+                                 status: 'In Progress')
     end
     it 'does not have a button to submit when I have no pets on the application' do
       visit "/applications/#{@app.id}"
-      expect(page).to_not have_content ("Submit Application")
+      expect(page).to_not have_content('Submit Application')
     end
-    
+
     it 'has a button to submit when I have pets on the application' do
       shelter = Shelter.create!(
         foster_program: true,
@@ -259,11 +258,11 @@ describe 'app show page' do
       petapp1 = PetApplication.create!(application_id: @app.id, pet_id: fido.id)
       petapp2 = PetApplication.create!(application_id: @app.id, pet_id: santa.id)
       visit "/applications/#{@app.id}"
-      expect(page).to have_button ("Submit Application")
-      fill_in "description", with: "I like dogs and cats"
-      click_button "Submit Application"
+      expect(page).to have_button('Submit Application')
+      fill_in 'description', with: 'I like dogs and cats'
+      click_button 'Submit Application'
       expect(current_path).to eq "/applications/#{@app.id}"
-      expect(page).to have_content("Status: Pending")
+      expect(page).to have_content('Status: Pending')
     end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -137,41 +137,39 @@ describe 'app show page' do
       expect(page).to have_content(fido.name)
     end
 
-    
+    it 'can populate multiple pets' do
+      shelter = Shelter.create!(
+        foster_program: true,
+        name: 'Dog house',
+        city: 'Springfield',
+        rank: 1
+      )
+      fido = shelter.pets.create!(
+        adoptable: true,
+        age: 1,
+        breed: 'weiner',
+        name: 'Fido'
+      )
+      fido2 = shelter.pets.create!(
+        adoptable: true,
+        age: 3,
+        breed: 'schnauzer',
+        name: 'Fido'
+      )
+      visit "/applications/#{@app.id}"
+      expect(@app.status).to eq('In Progress')
+      expect(page).to_not have_content('Fido')
+      expect(page).to have_content('Add a Pet to this Application')
+      expect(page).to have_field('pet_name')
+      fill_in 'pet_name', with: 'Fido'
+      click_on 'Submit'
+      expect(current_path).to eq("/applications/#{@app.id}")
+      expect(page).to have_link 'Fido', href: "/pets/#{fido.id}"
+      expect(page).to have_link 'Fido', href: "/pets/#{fido2.id}"
+    end
 
-      it 'can populate multiple pets' do
-        shelter = Shelter.create!(
-          foster_program: true,
-          name: 'Dog house',
-          city: 'Springfield',
-          rank: 1
-        )
-        fido = shelter.pets.create!(
-          adoptable: true,
-          age: 1,
-          breed: 'weiner',
-          name: 'Fido'
-        )
-        fido2 = shelter.pets.create!(
-          adoptable: true,
-          age: 3,
-          breed: 'schnauzer',
-          name: 'Fido'
-        )
-        visit "/applications/#{@app.id}"
-        expect(@app.status).to eq('In Progress')
-        expect(page).to_not have_content('Fido')
-        expect(page).to have_content('Add a Pet to this Application')
-        expect(page).to have_field('pet_name')
-        fill_in 'pet_name', with: 'Fido'
-        click_on 'Submit'
-        expect(current_path).to eq("/applications/#{@app.id}")
-        expect(page).to have_link 'Fido', href: "/pets/#{fido.id}"
-        expect(page).to have_link 'Fido', href: "/pets/#{fido2.id}"
-      end
-
-      it 'has a button to "Adopt this Pet", that adopts the pet' do
-        # 5. Add a Pet to an Application
+    it 'has a button to "Adopt this Pet", that adopts the pet' do
+      # 5. Add a Pet to an Application
       # As a visitor
       # When I visit an application's show page
       # And I search for a Pet by name
@@ -195,13 +193,10 @@ describe 'app show page' do
       visit "/applications/#{@app.id}"
       fill_in 'pet_name', with: 'Fido'
       click_on 'Submit'
-      save_and_open_page
-
       expect(page).to have_button('Adopt this Pet')
       click_on 'Adopt this Pet'
       expect(current_path).to eq("/applications/#{@app.id}")
       expect(page).to have_content("Pets Applying for: #{fido.name}")
-      save_and_open_page
-      end
+    end
   end
 end

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -199,4 +199,71 @@ describe 'app show page' do
       expect(page).to have_content("Pets Applying for: #{fido.name}")
     end
   end
+
+  describe 'submitting an application' do
+    # 6. Submit an Application
+
+    # As a visitor
+    # When I visit an application's show page
+    # And I have added one or more pets to the application
+    # Then I see a section to submit my application
+    # And in that section I see an input to enter why I would make a good owner for these pet(s)
+    # When I fill in that input
+    # And I click a button to submit this application
+    # Then I am taken back to the application's show page
+    # And I see an indicator that the application is "Pending"
+    # And I see all the pets that I want to adopt
+    # And I do not see a section to add more pets to this application
+
+
+# 7. No Pets on an Application
+
+# As a visitor
+# When I visit an application's show page
+# And I have not added any pets to the application
+# Then I do not see a section to submit my application
+
+    before(:each) do
+      @app = Application.create!(name: 'John Smith',
+                                address: '123 Fake Street',
+                                city: 'Springfield',
+                                state: 'IL',
+                                zipcode: 12345,
+                                description: 'I like dogs.',
+                                status: 'In Progress')
+    end
+    it 'does not have a button to submit when I have no pets on the application' do
+      visit "/applications/#{@app.id}"
+      expect(page).to_not have_content ("Submit Application")
+    end
+    
+    it 'has a button to submit when I have pets on the application' do
+      shelter = Shelter.create!(
+        foster_program: true,
+        name: 'Dog house',
+        city: 'Springfield',
+        rank: 1
+      )
+      fido = shelter.pets.create!(
+        adoptable: true,
+        age: 1,
+        breed: 'weiner',
+        name: 'Fido'
+      )
+      santa = shelter.pets.create!(
+        adoptable: true,
+        age: 1,
+        breed: 'whippet',
+        name: 'Santa\'s Little Helper'
+      )
+      petapp1 = PetApplication.create!(application_id: @app.id, pet_id: fido.id)
+      petapp2 = PetApplication.create!(application_id: @app.id, pet_id: santa.id)
+      visit "/applications/#{@app.id}"
+      expect(page).to have_content ("Submit Application")
+      fill_in "description", with: "I like dogs and cats"
+      click_button "Submit Application"
+      expect(current_path).to eq "/applications/#{@app.id}"
+      expect(page).to have_content("Status: Pending")
+    end
+  end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Application, type: :model do
   describe '.pets_list' do
     it 'should return a list of pets on the application' do
       app = Application.create!(name: 'John Smith',
-        address: '123 Fake Street',
-        city: 'Springfield',
-        state: 'IL',
-        zipcode: 12_345,
-        description: 'I like dogs.',
-        status: 'In Progress')
+                                address: '123 Fake Street',
+                                city: 'Springfield',
+                                state: 'IL',
+                                zipcode: 12_345,
+                                description: 'I like dogs.',
+                                status: 'In Progress')
       shelter = Shelter.create!(
         foster_program: true,
         name: 'Dog house',


### PR DESCRIPTION
This pull request completes user stories 6 and 7:

6. Submit an Application
As a visitor
When I visit an application's show page
And I have added one or more pets to the application
Then I see a section to submit my application
And in that section I see an input to enter why I would make a good owner for these pet(s)
When I fill in that input
And I click a button to submit this application
Then I am taken back to the application's show page
And I see an indicator that the application is "Pending"
And I see all the pets that I want to adopt
And I do not see a section to add more pets to this application
[ ] done

7. No Pets on an Application

As a visitor
When I visit an application's show page
And I have not added any pets to the application
Then I do not see a section to submit my application