### PR TITLE
User Stories 12 -14

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,6 +10,7 @@ class AdminController < ApplicationController
 
   def applications_update
     @application = Application.find(params[:id])
-    require 'pry'; binding.pry
+    @pet_application.create!(application_id: params[:id], pet_id: params[:petid])
+    redirect_to "/admin/applications/#{params[:id]}"
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -9,8 +9,8 @@ class AdminController < ApplicationController
   end
 
   def applications_update
-    @application = Application.find(params[:id])
-    @pet_application.create!(application_id: params[:id], pet_id: params[:petid])
+    @petapplication = PetApplication.find(params[:pet_application_id])
+    @petapplication.update(application_id: params[:id], pet_id: params[:petid], status: params[:status])
     redirect_to "/admin/applications/#{params[:id]}"
   end
 end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,4 +7,9 @@ class AdminController < ApplicationController
   def applications_show
     @application = Application.find(params[:id])
   end
+
+  def applications_update
+    @application = Application.find(params[:id])
+    require 'pry'; binding.pry
+  end
 end

--- a/app/views/admin/applications_show.html.erb
+++ b/app/views/admin/applications_show.html.erb
@@ -1,10 +1,12 @@
 <h1> <%= "Application Number: #{@application.id}" %> </h1>
 
 <% @application.pets.each do |pet| %>
-  <%= pet.name %>
-  <% form_with url: "/admin/applications_show", method: :patch do |form| %>
-  <%= form.button "Approve #{pet.name} for #{@application.name}", formmethod: :patch, data: { status: "Approved" } %>
-  <%= form.button "Reject #{pet.name} for #{@application.name}", formmethod: :patch, data: { status: "Rejected" } %>
-  <% end %>
+  <%= pet.name %> <br>
+  <%= form_with url: "/admin/applications/#{@application.id}", method: :patch do |form| %>
+  <%= form.hidden_field :petid, value: "#{pet.id}" %>
+  <%= form.hidden_field :status, value: "pending" %>
+  <%= form.button "Approve #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Approved"  %>
+  <%= form.button "Reject #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Rejected"  %>
+<% end %>
   <%@application.pet_applications.where(pet_id: pet.id)%>
 <% end %>

--- a/app/views/admin/applications_show.html.erb
+++ b/app/views/admin/applications_show.html.erb
@@ -1,5 +1,10 @@
-<h1> <%= "Application Number: #{@application.id}" %>
+<h1> <%= "Application Number: #{@application.id}" %> </h1>
 
 <% @application.pets.each do |pet| %>
   <%= pet.name %>
+  <% form_with url: "/admin/applications_show", method: :patch do |form| %>
+  <%= form.button "Approve #{pet.name} for #{@application.name}", formmethod: :patch, data: { status: "Approved" } %>
+  <%= form.button "Reject #{pet.name} for #{@application.name}", formmethod: :patch, data: { status: "Rejected" } %>
+  <% end %>
+  <%@application.pet_applications.where(pet_id: pet.id)%>
 <% end %>

--- a/app/views/admin/applications_show.html.erb
+++ b/app/views/admin/applications_show.html.erb
@@ -3,14 +3,15 @@
 <% @application.pets.each do |pet| %>
   <%= pet.name %> <br>
   <%= form_with url: "/admin/applications/#{@application.id}", method: :patch do |form| %>
+      <%= form.hidden_field :pet_application_id, value: @application.pet_applications.where(pet_id: pet.id).first.id %>
     <%= form.hidden_field :petid, value: "#{pet.id}" %>
     <%= form.hidden_field :status, value: "Pending" %>
     <% if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Pending' %>
       <%= form.button "Approve #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Approved"  %>
       <%= form.button "Reject #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Rejected"  %>
     <%else  %>
-      <%= "#{@pet.name} approved for #{@aplication.name}" if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Approved' %>
-      <%= "#{@pet.name} rejected for #{@aplication.name}" if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Rejected' %>
+      <%= "#{pet.name} approved for #{@application.name}" if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Approved' %>
+      <%= "#{pet.name} rejected for #{@application.name}" if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Rejected' %>
     <% end %>
   <% end %>
   <%@application.pet_applications.where(pet_id: pet.id)%>

--- a/app/views/admin/applications_show.html.erb
+++ b/app/views/admin/applications_show.html.erb
@@ -3,10 +3,15 @@
 <% @application.pets.each do |pet| %>
   <%= pet.name %> <br>
   <%= form_with url: "/admin/applications/#{@application.id}", method: :patch do |form| %>
-  <%= form.hidden_field :petid, value: "#{pet.id}" %>
-  <%= form.hidden_field :status, value: "pending" %>
-  <%= form.button "Approve #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Approved"  %>
-  <%= form.button "Reject #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Rejected"  %>
-<% end %>
+    <%= form.hidden_field :petid, value: "#{pet.id}" %>
+    <%= form.hidden_field :status, value: "Pending" %>
+    <% if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Pending' %>
+      <%= form.button "Approve #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Approved"  %>
+      <%= form.button "Reject #{pet.name} for #{@application.name}", formmethod: :patch, type: "submit", name: "status", value: "Rejected"  %>
+    <%else  %>
+      <%= "#{@pet.name} approved for #{@aplication.name}" if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Approved' %>
+      <%= "#{@pet.name} rejected for #{@aplication.name}" if @application.pet_applications.where(pet_id: pet.id).pluck(:status).first == 'Rejected' %>
+    <% end %>
+  <% end %>
   <%@application.pet_applications.where(pet_id: pet.id)%>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,4 +44,5 @@ Rails.application.routes.draw do
 
   get '/admin/shelters', to: 'admin#shelters_index'
   get '/admin/applications/:id', to: 'admin#applications_show'
+  patch 'admin/applications/:id', to: 'admin#applications_update'
 end

--- a/db/migrate/20230209223727_create_pet_applications.rb
+++ b/db/migrate/20230209223727_create_pet_applications.rb
@@ -3,6 +3,7 @@ class CreatePetApplications < ActiveRecord::Migration[5.2]
     create_table :pet_applications do |t|
       t.references :pet, foreign_key: true
       t.references :application, foreign_key: true
+      t.string :status, default: "Pending", null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,71 +10,73 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_230_209_223_727) do
+ActiveRecord::Schema.define(version: 2023_02_09_223727) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'applications', force: :cascade do |t|
-    t.string 'name'
-    t.string 'address'
-    t.string 'city'
-    t.string 'state'
-    t.integer 'zipcode'
-    t.string 'description'
-    t.string 'status'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "applications", force: :cascade do |t|
+    t.string "name"
+    t.string "address"
+    t.string "city"
+    t.string "state"
+    t.integer "zipcode"
+    t.string "description"
+    t.string "status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'pet_applications', force: :cascade do |t|
-    t.bigint 'pet_id'
-    t.bigint 'application_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['application_id'], name: 'index_pet_applications_on_application_id'
-    t.index ['pet_id'], name: 'index_pet_applications_on_pet_id'
+  create_table "pet_applications", force: :cascade do |t|
+    t.bigint "pet_id"
+    t.bigint "application_id"
+    t.string "status", default: "Pending", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_id"], name: "index_pet_applications_on_application_id"
+    t.index ["pet_id"], name: "index_pet_applications_on_pet_id"
   end
 
-  create_table 'pets', force: :cascade do |t|
-    t.boolean 'adoptable'
-    t.integer 'age'
-    t.string 'breed'
-    t.string 'name'
-    t.bigint 'shelter_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['shelter_id'], name: 'index_pets_on_shelter_id'
+  create_table "pets", force: :cascade do |t|
+    t.boolean "adoptable"
+    t.integer "age"
+    t.string "breed"
+    t.string "name"
+    t.bigint "shelter_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["shelter_id"], name: "index_pets_on_shelter_id"
   end
 
-  create_table 'shelters', force: :cascade do |t|
-    t.boolean 'foster_program'
-    t.string 'name'
-    t.string 'city'
-    t.integer 'rank'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "shelters", force: :cascade do |t|
+    t.boolean "foster_program"
+    t.string "name"
+    t.string "city"
+    t.integer "rank"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'veterinarians', force: :cascade do |t|
-    t.boolean 'on_call'
-    t.integer 'review_rating'
-    t.string 'name'
-    t.bigint 'veterinary_office_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['veterinary_office_id'], name: 'index_veterinarians_on_veterinary_office_id'
+  create_table "veterinarians", force: :cascade do |t|
+    t.boolean "on_call"
+    t.integer "review_rating"
+    t.string "name"
+    t.bigint "veterinary_office_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["veterinary_office_id"], name: "index_veterinarians_on_veterinary_office_id"
   end
 
-  create_table 'veterinary_offices', force: :cascade do |t|
-    t.boolean 'boarding_services'
-    t.integer 'max_patient_capacity'
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "veterinary_offices", force: :cascade do |t|
+    t.boolean "boarding_services"
+    t.integer "max_patient_capacity"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_foreign_key 'pet_applications', 'applications'
-  add_foreign_key 'pet_applications', 'pets'
-  add_foreign_key 'pets', 'shelters'
-  add_foreign_key 'veterinarians', 'veterinary_offices'
+  add_foreign_key "pet_applications", "applications"
+  add_foreign_key "pet_applications", "pets"
+  add_foreign_key "pets", "shelters"
+  add_foreign_key "veterinarians", "veterinary_offices"
 end

--- a/spec/features/admin/applications_show_spec.rb
+++ b/spec/features/admin/applications_show_spec.rb
@@ -41,12 +41,11 @@ describe 'admin applications show' do
   # Then I'm taken back to the admin application show page
   # And next to the pet that I approved, I do not see a button to approve this pet
   # And instead I see an indicator next to the pet that they have been approved
-  xit 'should have a list of the pets on the application' do
+  it 'should have a list of the pets on the application' do
     visit "/admin/applications/#{@app.id}"
     expect(page).to have_content("Application Number: #{@app.id}")
     expect(page).to have_content(@fido.name)
     expect(page).to have_content(@santa.name)
-    save_and_open_page
   end
 
   it 'can approve pets' do

--- a/spec/features/admin/applications_show_spec.rb
+++ b/spec/features/admin/applications_show_spec.rb
@@ -56,7 +56,6 @@ describe 'admin applications show' do
     expect(current_path).to eq "/admin/applications/#{@app.id}"
     expect(page).to_not have_button("Approve #{@fido.name} for #{@app.name}")
     expect(page).to have_content("#{@fido.name} approved for #{@app.name}")
-    save_and_open_page
   end
 
   it 'can reject pets' do
@@ -66,6 +65,5 @@ describe 'admin applications show' do
     expect(current_path).to eq "/admin/applications/#{@app.id}"
     expect(page).to_not have_button("Reject #{@fido.name} for #{@app.name}")
     expect(page).to have_content("#{@fido.name} rejected for #{@app.name}")
-    save_and_open_page
   end
 end

--- a/spec/features/admin/applications_show_spec.rb
+++ b/spec/features/admin/applications_show_spec.rb
@@ -52,19 +52,20 @@ describe 'admin applications show' do
   it 'can approve pets' do
     visit "/admin/applications/#{@app.id}"
     expect(page).to have_button("Approve #{@fido.name} for #{@app.name}")
-    
     click_button("Approve #{@fido.name} for #{@app.name}")
     expect(current_path).to eq "/admin/applications/#{@app.id}"
     expect(page).to_not have_button("Approve #{@fido.name} for #{@app.name}")
     expect(page).to have_content("#{@fido.name} approved for #{@app.name}")
+    save_and_open_page
   end
 
-  xit 'can reject pets' do
+  it 'can reject pets' do
     visit "/admin/applications/#{@app.id}"
     expect(page).to have_button("Reject #{@fido.name} for #{@app.name}")
     click_button("Reject #{@fido.name} for #{@app.name}")
     expect(current_path).to eq "/admin/applications/#{@app.id}"
     expect(page).to_not have_button("Reject #{@fido.name} for #{@app.name}")
     expect(page).to have_content("#{@fido.name} rejected for #{@app.name}")
+    save_and_open_page
   end
 end

--- a/spec/features/admin/applications_show_spec.rb
+++ b/spec/features/admin/applications_show_spec.rb
@@ -41,16 +41,18 @@ describe 'admin applications show' do
   # Then I'm taken back to the admin application show page
   # And next to the pet that I approved, I do not see a button to approve this pet
   # And instead I see an indicator next to the pet that they have been approved
-  it 'should have a list of the pets on the application' do
+  xit 'should have a list of the pets on the application' do
     visit "/admin/applications/#{@app.id}"
     expect(page).to have_content("Application Number: #{@app.id}")
     expect(page).to have_content(@fido.name)
     expect(page).to have_content(@santa.name)
+    save_and_open_page
   end
 
-  xit 'can approve pets' do
+  it 'can approve pets' do
     visit "/admin/applications/#{@app.id}"
     expect(page).to have_button("Approve #{@fido.name} for #{@app.name}")
+    
     click_button("Approve #{@fido.name} for #{@app.name}")
     expect(current_path).to eq "/admin/applications/#{@app.id}"
     expect(page).to_not have_button("Approve #{@fido.name} for #{@app.name}")


### PR DESCRIPTION
This completes user stories 12-14:

[ ] done

12. Approving a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved
[ ] done

13. Rejecting a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected
14. Approved/Rejected Pets on one Application do not affect other Applications

As a visitor
When there are two applications in the system for the same pet
When I visit the admin application show page for one of the applications
And I approve or reject the pet for that application
When I visit the other application's admin show page
Then I do not see that the pet has been accepted or rejected for that application
And instead I see buttons to approve or reject the pet for this specific application